### PR TITLE
Tweak layer algorithm for bio overrides

### DIFF
--- a/src/shared/getVisibleLayers.js
+++ b/src/shared/getVisibleLayers.js
@@ -74,7 +74,7 @@ function getVisibleLayers(petAppearance, itemAppearances) {
       layer.source === "item" &&
       layer.bodyId !== "0" &&
       (petAppearance.pose === "UNCONVERTED" ||
-        petOccupiedOrRestrictedZoneIds.has(layer.zone.id))
+        petOccupiedZoneIds.has(layer.zone.id))
     ) {
       return false;
     }


### PR DESCRIPTION
Allows for bio layers such as `Mouth` to be overridden.

Example: https://impress-2020.openneo.net/outfits/new?name=&species=5&color=8&pose=HAPPY_MASC&objects%5B%5D=84818